### PR TITLE
Simplify instructions for running jobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ The purpose of this repo is to build data transformation applications.  The code
 ## Pre-requisites
 Please make sure you have the following installed and can run them
 * Python 3.6 or later
-* Apache Spark 2.4.x
-* PySpark
-* The ability to run spark-submit with the --py-files option
+* PySpark (`pip install pyspark`)
 * PyCharm IDE
 
 The following instructions assumes the command to run Python 3.X is python3
@@ -14,34 +12,27 @@ The following instructions assumes the command to run Python 3.X is python3
 ## Setup Process
 * Clone the repo
 * cd project/src
-* Build: package.sh
-* Test: python3 -m unittest
+* Test: `python3 -m unittest`
 
 ## Pycharm Setup
 * Open downloaded repo in PyCharm
 * In Preferences > Project > Project Structure set src directory to Sources (source root)
 
-## Running Data Apps
-* Package the project with
-```
-package.sh
-```
-
 ###
 
 
 ### Wordcount
-* Sample data is available in the src/test/wordcount/data directory
+* Sample data is available in the `src/test/wordcount/data` directory
 This applications will count the occurrences of a word within a text file. By default this app will read from the words.txt file and write to the target folder.  Pass in the input source path and output path directory to the spark-submit command below if you wish to use different files.
 
 ```
-spark-submit --master local[2]  --py-files thoughtworks.zip job_runner.py WordCount $(INPUT_LOCATION) $(OUTPUT_LOCATION)
+python3 job_runner.py WordCount $(INPUT_LOCATION) $(OUTPUT_LOCATION)
 ```
 
 Currently this application is a skeleton with ignored tests.  Please unignore the tests and build the wordcount application.
 
 ### Citibike multi-step pipeline
-* Sample data is available in the src/test/citibike/data directory
+* Sample data is available in the `src/test/citibike/data` directory
 This application takes bike trip information and calculates the "as the crow flies" distance traveled for each trip.  
 The application is run in two steps.
 * First the data will be ingested from a sources and transformed to parquet format.
@@ -50,12 +41,12 @@ The application is run in two steps.
 
 * To ingest data from external source to datalake:
 ```
-spark-submit --master local[2]  --py-files thoughtworks.zip job_runner.py DailyDriver $(INPUT_LOCATION) $(OUTPUT_LOCATION)
+python3 job_runner.py DailyDriver $(INPUT_LOCATION) $(OUTPUT_LOCATION)
 ```
 
 * To transform Citibike data:
 ```
-spark-submit --master local[2]  --py-files thoughtworks.zip job_runner.py CitiBikeTransformer $(INPUT_LOCATION) $(OUTPUT_LOCATION)
+python3 job_runner.py CitiBikeTransformer $(INPUT_LOCATION) $(OUTPUT_LOCATION)
 ```
 
 Currently this application is a skeleton with ignored tests.  Please unignore the tests and build the Citibike transformation application.


### PR DESCRIPTION
Hello, ThoughtWorks!  

I noticed your build/run process packages up a zip file and throws it at the full spark-submit machinery that you'd use on a cluster; is that needed for this simple local project?  Seems like it could be easier for people to set up and run by just using the default local mode -- no need for a full Spark install, just run `python3 job_runner.py ...`.

I simplified the README to what works for me, but perhaps there are some use cases or environments that I'm not aware of.

Thanks!