### PR TITLE
Code style fixes.

### DIFF
--- a/src/job_runner.py
+++ b/src/job_runner.py
@@ -2,18 +2,18 @@ import sys
 import logging
 from thoughtworks import wordcount_main, citibike_main, daily_driver_main
 
-if __name__ == '__main__':
+LOG_FILENAME = 'project.log'
 
-    LOG_FILENAME = 'project.log'
+
+def main():
     logging.basicConfig(filename=LOG_FILENAME, level=logging.INFO)
 
     for num, name in enumerate(sys.argv, start=0):
         print("args {}: {}".format(num, name))
 
-    job_name = None
     if len(sys.argv) > 1:
-         job_name = sys.argv[1]
-         print(job_name)
+        job_name = sys.argv[1]
+        print(job_name)
     else:
         print("No job name supplied. Please specify WordCount, CitiBike or DailyDriver")
         logging.warning("No job name supplied. Please specify WordCount, CitiBikeTransformer or DailyDriver")
@@ -24,3 +24,7 @@ if __name__ == '__main__':
         citibike_main.main(sys.argv)
     elif job_name == "DailyDriver":
         daily_driver_main.main(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/test/citibike/test_CitibikeTransformer.py
+++ b/src/test/citibike/test_CitibikeTransformer.py
@@ -6,12 +6,12 @@ from pyspark.sql import functions as F
 
 import thoughtworks.citibike.CitibikeTransformer as CitibikeTransformer
 
-citibikeBaseDataColumns = [
+BASE_DATA_COLUMNS = [
     "tripduration", "starttime", "stoptime", "start_station_id", "start_station_name", "start_station_latitude",
     "start_station_longitude", "end_station_id", "end_station_name", "end_station_latitude", "end_station_longitude",
     "bikeid", "usertype", "birth_year", "gender"]
 
-sampleCitibikeData = [
+SAMPLE_DATA = [
     [328, "2017-07-01 00:00:08", "2017-07-01 00:05:37", 3242, "Schermerhorn St & Court St", 40.69102925677968,
      -73.99183362722397, 3397, "Court St & Nelson St", 40.6763947, -73.99869893, 27937, "Subscriber", 1984, 2],
     [1496, "2017-07-01 00:00:18", "2017-07-01 00:25:15", 3233, "E 48 St & 5 Ave", 40.75724567911726, -73.97805914282799,
@@ -19,6 +19,7 @@ sampleCitibikeData = [
     [1067, "2017-07-01 00:16:31", "2017-07-01 00:34:19", 448, "W 37 St & 10 Ave", 40.75660359, -73.9979009, 487,
      "E 20 St & FDR Drive", 40.73314259, -73.97573881, 27084, "Subscriber", 1990, 2]
 ]
+
 
 class CitibikeTransformerTest(unittest.TestCase):
 
@@ -33,7 +34,7 @@ class CitibikeTransformerTest(unittest.TestCase):
 
     # CitibikeTransformer application
 
-    #@unittest.skip("Ignore test")
+    @unittest.skip("Ignore test")
     def test_acceptance_for_basic_use(self):
         print("test_acceptance_for_basic_use")
         root_directory = os.getcwd()
@@ -42,27 +43,27 @@ class CitibikeTransformerTest(unittest.TestCase):
         os.makedirs(ingest_directory, exist_ok=False)
         transform_directory = data_directory + "/transform"
         os.makedirs(transform_directory, exist_ok=False)
-        input_DF = self.spark.createDataFrame(sampleCitibikeData, citibikeBaseDataColumns)
-        input_DF.write.parquet(ingest_directory, mode='append')
+        input_df = self.spark.createDataFrame(SAMPLE_DATA, BASE_DATA_COLUMNS)
+        input_df.write.parquet(ingest_directory, mode='append')
         # Run test app
         CitibikeTransformer.run(self.spark, ingest_directory, transform_directory)
-        transformed_DF = self.spark.read.parquet(transform_directory)
-        expected_columns = set(citibikeBaseDataColumns)
-        new_columns = set(transformed_DF.select(*citibikeBaseDataColumns).columns)
-        input = set(input_DF.schema)
-        transformed = set(transformed_DF.schema)
-        #Restore directories to original state
+        transformed_df = self.spark.read.parquet(transform_directory)
+        expected_columns = set(BASE_DATA_COLUMNS)
+        new_columns = set(transformed_df.select(*BASE_DATA_COLUMNS).columns)
+        input_ = set(input_df.schema)
+        transformed = set(transformed_df.schema)
+        # Restore directories to original state
         shutil.rmtree(data_directory)
         os.chdir(root_directory)
-        #New data should have all of the old data
-        #Check columns
+        # New data should have all of the old data
+        # Check columns
         with self.subTest():
             self.assertEqual(new_columns, expected_columns)
-        #Check schema
+        # Check schema
         with self.subTest():
-            self.assertTrue(input.issubset(transformed))
+            self.assertTrue(input_.issubset(transformed))
 
-    #@unittest.skip("Ignore test")
+    @unittest.skip("Ignore test")
     def test_acceptance_for_advanced_use(self):
         print("test_acceptance_for_advanced_use")
         root_directory = os.getcwd()
@@ -72,14 +73,14 @@ class CitibikeTransformerTest(unittest.TestCase):
         os.makedirs(ingest_directory, exist_ok=False)
         transform_directory = data_directory + "/transform"
         os.makedirs(transform_directory, exist_ok=False)
-        input_DF = self.spark.createDataFrame(sampleCitibikeData, citibikeBaseDataColumns)
-        input_DF.write.parquet(ingest_directory, mode='append')
+        input_df = self.spark.createDataFrame(SAMPLE_DATA, BASE_DATA_COLUMNS)
+        input_df.write.parquet(ingest_directory, mode='append')
         # Run test app
         CitibikeTransformer.run(self.spark, ingest_directory, transform_directory)
-        transformed_DF = self.spark.read.parquet(transform_directory)
-        transformed_sorted_DF = transformed_DF.sort(F.col("tripduration"))
-        actual_data = transformed_sorted_DF.collect()
-        expectedData = [
+        transformed_df = self.spark.read.parquet(transform_directory)
+        transformed_sorted_df = transformed_df.sort(F.col("tripduration"))
+        actual_data = transformed_sorted_df.collect()
+        expected_data = [
             Row(328, "2017-07-01 00:00:08", "2017-07-01 00:05:37", 3242, "Schermerhorn St & Court St",
                 40.69102925677968, -73.99183362722397, 3397, "Court St & Nelson St", 40.6763947, -73.99869893, 27937,
                 "Subscriber", 1984, 2, 1.07),
@@ -88,14 +89,14 @@ class CitibikeTransformerTest(unittest.TestCase):
                 0.92),
             Row(1067, "2017-07-01 00:16:31", "2017-07-01 00:34:19", 448, "W 37 St & 10 Ave", 40.75660359, -73.9979009,
                 487, "E 20 St & FDR Drive", 40.73314259, -73.97573881, 27084, "Subscriber", 1990, 2.0, 1.99)]
-        expectedData.sort()
-        #Restore directories to original state
+        expected_data.sort()
+        # Restore directories to original state
         shutil.rmtree(data_directory)
         os.chdir(root_directory)
-        for i in range(0, len(expectedData)):
-            for j in range(0, len(expectedData[i])):
+        for i in range(0, len(expected_data)):
+            for j in range(0, len(expected_data[i])):
                 with self.subTest((i, j)):
-                    self.assertEqual(actual_data[i][j], expectedData[i][j])
+                    self.assertEqual(actual_data[i][j], expected_data[i][j])
 
 
 if __name__ == '__main__':

--- a/src/test/citibike/test_DailyDriver.py
+++ b/src/test/citibike/test_DailyDriver.py
@@ -1,9 +1,9 @@
 import unittest
 import sys, os, shutil
-import csv
 from pyspark.sql import SparkSession
 
 import thoughtworks.citibike.DailyDriver as DailyDriver
+
 
 class DailyDriverTest(unittest.TestCase):
 
@@ -16,33 +16,34 @@ class DailyDriverTest(unittest.TestCase):
     def tearDown(self):
         self.spark.stop()
 
-    #@unittest.skip("Ignore test")
+    @unittest.skip("Ignore test")
     def test_daily_driver_ingestion(self):
         print("test_daily_driver_ingestion")
         root_directory = os.getcwd()
         file_directory = root_directory + "/test-result"
         os.makedirs(file_directory, exist_ok=False)
-        #Create input file
-        input_csv = file_directory+"/input.csv"
+        # Create input file
+        input_csv = file_directory + "/input.csv"
         output_directory = root_directory + "/output"
         lines = ["first_field,field with space, fieldWithOuterSpaces ", "3,1,4", "1,5,2"]
         with open(input_csv, 'w') as f:
             for line in lines:
                 print(line, file=f)
         DailyDriver.run(self.spark, input_csv, output_directory)
-        #Read results
+        # Read results
         parquet_directory = self.spark.read.parquet(output_directory)
         parquet_directory_count = parquet_directory.count()
         with self.subTest():
-            self.assertEqual(parquet_directory_count,2)
+            self.assertEqual(parquet_directory_count, 2)
         parquet_directory_columns = parquet_directory.columns
         expected_column_headings = ["first_field", "field_with_space", "_fieldWithOuterSpaces_"]
-        #Restore directories to original state
+        # Restore directories to original state
         shutil.rmtree(file_directory)
         shutil.rmtree(output_directory)
         os.chdir(root_directory)
         with self.subTest():
             self.assertEqual(parquet_directory_columns, expected_column_headings)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/wordcount/test_WordCount.py
+++ b/src/test/wordcount/test_WordCount.py
@@ -4,6 +4,7 @@ from pyspark.sql import SparkSession
 
 import thoughtworks.wordcount.WordCount as WordCount
 
+
 class WordCountTest(unittest.TestCase):
 
     def setUp(self):
@@ -15,7 +16,7 @@ class WordCountTest(unittest.TestCase):
     def tearDown(self):
         self.spark.stop()
 
-# Word Count application
+    # Word Count application
     @unittest.skip("Ignore test")
     def test_acceptance_for_basic_use(self):
         print("test_acceptance_for_basic_use")
@@ -26,19 +27,20 @@ class WordCountTest(unittest.TestCase):
         root_directory = os.getcwd()
         file_directory = root_directory + "/test-result"
         os.makedirs(file_directory, exist_ok=False)
-        #Create input file
-        input_file = file_directory+"/input.txt"
-        lines = ["In my younger and more vulnerable years my father gave me some advice that I've been turning over in my mind ever since. \"Whenever you feel like criticising any one,\" he told me, \"just remember that all the people in this world haven't had the advantages that you've had.\"",
-        "Most of the big shore places were closed now and there were hardly any lights except the shadowy, moving glow of a ferryboat across the Sound. And as the moon rose higher the inessential houses began to melt away until gradually I became aware of the old island here that flowered once for Dutch sailors' eyes--a fresh, green breast of the new world. Its vanished trees, the trees that had made way for Gatsby's house, had once pandered in whispers to the last and greatest of all human dreams; for a transitory enchanted moment man must have held his breath in the presence of this continent, compelled into an aesthetic contemplation he neither understood nor desired, face to face for the last time in history with something commensurate to his capacity for wonder.",
-        "And as I sat there, brooding on the old unknown world, I thought of Gatsby's wonder when he first picked out the green light at the end of Daisy's dock. He had come a long way to this blue lawn and his dream must have seemed so close that he could hardly fail to grasp it. He did not know that it was already behind him, somewhere back in that vast obscurity beyond the city, where the dark fields of the republic rolled on under the night.",
-        "Gatsby believed in the green light, the orgastic future that year by year recedes before us. It eluded us then, but that's no matter--tomorrow we will run faster, stretch out our arms farther.... And one fine morning----",
-        "So we beat on, boats against the current, borne back ceaselessly into the past.      "]
+        # Create input file
+        input_file = file_directory + "/input.txt"
+        lines = [
+            "In my younger and more vulnerable years my father gave me some advice that I've been turning over in my mind ever since. \"Whenever you feel like criticising any one,\" he told me, \"just remember that all the people in this world haven't had the advantages that you've had.\"",
+            "Most of the big shore places were closed now and there were hardly any lights except the shadowy, moving glow of a ferryboat across the Sound. And as the moon rose higher the inessential houses began to melt away until gradually I became aware of the old island here that flowered once for Dutch sailors' eyes--a fresh, green breast of the new world. Its vanished trees, the trees that had made way for Gatsby's house, had once pandered in whispers to the last and greatest of all human dreams; for a transitory enchanted moment man must have held his breath in the presence of this continent, compelled into an aesthetic contemplation he neither understood nor desired, face to face for the last time in history with something commensurate to his capacity for wonder.",
+            "And as I sat there, brooding on the old unknown world, I thought of Gatsby's wonder when he first picked out the green light at the end of Daisy's dock. He had come a long way to this blue lawn and his dream must have seemed so close that he could hardly fail to grasp it. He did not know that it was already behind him, somewhere back in that vast obscurity beyond the city, where the dark fields of the republic rolled on under the night.",
+            "Gatsby believed in the green light, the orgastic future that year by year recedes before us. It eluded us then, but that's no matter--tomorrow we will run faster, stretch out our arms farther.... And one fine morning----",
+            "So we beat on, boats against the current, borne back ceaselessly into the past.      "]
         with open(input_file, 'w') as f:
             for line in lines:
                 f.write(line)
-        #Run test app
+        # Run test app
         WordCount.run(self.spark, input_file, file_directory)
-        #Read results
+        # Read results
         os.chdir(file_directory)
         files = glob.glob('*.{}'.format('csv'))
         actual_lines = []
@@ -55,22 +57,23 @@ class WordCountTest(unittest.TestCase):
             'continent,1', 'could,1', 'criticising,1', 'current,1', "daisy's,1", 'dark,1', 'desired,1', 'did,1', 'dock,1', 'dream,1',
             'dreams,1', 'dutch,1', 'eluded,1', 'enchanted,1', 'end,1', 'ever,1', 'except,1', 'eyes,1', 'face,2', 'fail,1', 'farther,1',
             'faster,1', 'father,1', 'feel,1', 'ferryboat,1', 'fields,1', 'fine,1', 'first,1', 'flowered,1', 'for,5', 'fresh,1', 'future,1',
-             "gatsby's,2", 'gatsby,1', 'gave,1', 'glow,1', 'gradually,1', 'grasp,1', 'greatest,1', 'green,3', 'had,5', 'hardly,2', 'have,2',
-             "haven't,1", 'he,6', 'held,1', 'here,1', 'higher,1', 'him,1', 'his,3', 'history,1', 'house,1', 'houses,1', 'human,1', "i've,1",
-             'i,3', 'in,8', 'inessential,1', 'into,2', 'island,1', 'it,3', 'its,1', 'just,1', 'know,1', 'last,2', 'lawn,1', 'light,2',
-             'lights,1', 'like,1', 'long,1', 'made,1', 'man,1', 'matter,1', 'me,2', 'melt,1', 'mind,1', 'moment,1', 'moon,1', 'more,1',
-             'morning,1', 'most,1', 'moving,1', 'must,2', 'my,3', 'neither,1', 'new,1', 'night,1', 'no,1', 'nor,1', 'not,1', 'now,1',
-             'obscurity,1', 'of,9', 'old,2', 'on,3', 'once,2', 'one,2', 'orgastic,1', 'our,1', 'out,2', 'over,1', 'pandered,1', 'past,1',
-             'people,1', 'picked,1', 'places,1', 'presence,1', 'recedes,1', 'remember,1', 'republic,1', 'rolled,1', 'rose,1', 'run,1',
-             "sailors',1", 'sat,1', 'seemed,1', 'shadowy,1', 'shore,1', 'since,1', 'so,2', 'some,1', 'something,1', 'somewhere,1', 'sound,1',
-             'stretch,1', "that's,1", 'that,9', 'the,24', 'then,1', 'there,2', 'this,3', 'thought,1', 'time,1', 'to,6', 'told,1', 'tomorrow,1',
-             'transitory,1', 'trees,2', 'turning,1', 'under,1', 'understood,1', 'unknown,1', 'until,1', 'us,2', 'vanished,1', 'vast,1',
-             'vulnerable,1', 'was,1', 'way,2', 'we,2', 'were,2', 'when,1', 'whenever,1', 'where,1', 'whispers,1', 'will,1', 'with,1',
-             'wonder,2', 'world,3', 'year,2', 'years,1', "you've,1", 'you,1', 'younger,1']
-        #Clean up test side effects
+            "gatsby's,2", 'gatsby,1', 'gave,1', 'glow,1', 'gradually,1', 'grasp,1', 'greatest,1', 'green,3', 'had,5', 'hardly,2', 'have,2',
+            "haven't,1", 'he,6', 'held,1', 'here,1', 'higher,1', 'him,1', 'his,3', 'history,1', 'house,1', 'houses,1', 'human,1', "i've,1",
+            'i,3', 'in,8', 'inessential,1', 'into,2', 'island,1', 'it,3', 'its,1', 'just,1', 'know,1', 'last,2', 'lawn,1', 'light,2',
+            'lights,1', 'like,1', 'long,1', 'made,1', 'man,1', 'matter,1', 'me,2', 'melt,1', 'mind,1', 'moment,1', 'moon,1', 'more,1',
+            'morning,1', 'most,1', 'moving,1', 'must,2', 'my,3', 'neither,1', 'new,1', 'night,1', 'no,1', 'nor,1', 'not,1', 'now,1',
+            'obscurity,1', 'of,9', 'old,2', 'on,3', 'once,2', 'one,2', 'orgastic,1', 'our,1', 'out,2', 'over,1', 'pandered,1', 'past,1',
+            'people,1', 'picked,1', 'places,1', 'presence,1', 'recedes,1', 'remember,1', 'republic,1', 'rolled,1', 'rose,1', 'run,1',
+            "sailors',1", 'sat,1', 'seemed,1', 'shadowy,1', 'shore,1', 'since,1', 'so,2', 'some,1', 'something,1', 'somewhere,1', 'sound,1',
+            'stretch,1', "that's,1", 'that,9', 'the,24', 'then,1', 'there,2', 'this,3', 'thought,1', 'time,1', 'to,6', 'told,1', 'tomorrow,1',
+            'transitory,1', 'trees,2', 'turning,1', 'under,1', 'understood,1', 'unknown,1', 'until,1', 'us,2', 'vanished,1', 'vast,1',
+            'vulnerable,1', 'was,1', 'way,2', 'we,2', 'were,2', 'when,1', 'whenever,1', 'where,1', 'whispers,1', 'will,1', 'with,1',
+            'wonder,2', 'world,3', 'year,2', 'years,1', "you've,1", 'you,1', 'younger,1']
+        # Clean up test side effects
         os.chdir(root_directory)
         shutil.rmtree(file_directory)
-        self.assertEqual(actual_lines,expected_lines)
+        self.assertEqual(actual_lines, expected_lines)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/wordcount/test_WordCountUtilsTest.py
+++ b/src/test/wordcount/test_WordCountUtilsTest.py
@@ -5,13 +5,15 @@ from pyspark.sql import Row
 
 import thoughtworks.wordcount.utils as w
 
+
 def dataframe_converter(df):
     col = df.columns
     collected_counts = df.collect()
     word_counts = []
-    [word_counts.append((i.asDict().get(col[0]),i.asDict().get(col[1]))) for i in collected_counts]
+    [word_counts.append((i.asDict().get(col[0]), i.asDict().get(col[1]))) for i in collected_counts]
     word_counts.sort
     return word_counts
+
 
 class WordCountUtilsTest(unittest.TestCase):
 
@@ -24,7 +26,7 @@ class WordCountUtilsTest(unittest.TestCase):
     def tearDown(self):
         self.spark.stop()
 
-# Split Words
+    # Split Words
     @unittest.skip("Ignore test")
     def test_split_words_by_spaces(self):
         print("test_split_words_by_spaces")
@@ -45,7 +47,7 @@ class WordCountUtilsTest(unittest.TestCase):
     def test_split_words_by_semicolon(self):
         print("test_split_words_by_semicolon")
 
-# Count Words
+    # Count Words
     @unittest.skip("Ignore test")
     def test_count_words_basic(self):
         print("test_count_words_basic")
@@ -58,10 +60,11 @@ class WordCountUtilsTest(unittest.TestCase):
     def test_case_insensitivity(self):
         print("test_case_insensitivity")
 
-# Sort Words
+    # Sort Words
     @unittest.skip("Ignore test")
     def test_ordering_words(self):
         print("test_ordering_words")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/thoughtworks/citibike/CitibikeTransformer.py
+++ b/src/thoughtworks/citibike/CitibikeTransformer.py
@@ -7,6 +7,6 @@ from pyspark.sql import SparkSession
 def run(spark, ingestPath, transformationPath):
     df = spark.read.parquet(ingestPath)
     df.show()
-    df = citibike_utils.computeDistances(spark, df)
+    df = citibike_utils.compute_distances(spark, df)
     df.show()
     df.write.parquet(transformationPath,mode='append')

--- a/src/thoughtworks/citibike/DailyDriver.py
+++ b/src/thoughtworks/citibike/DailyDriver.py
@@ -1,9 +1,7 @@
-import sys
 import logging
-from pyspark.sql import SparkSession
+
 
 def run(spark, ingest_path, transformation_path):
-
     logging.info("Reading text file from: " + ingest_path)
 
     input_df = spark.read.format("org.apache.spark.csv").option("header", True).csv(ingest_path)

--- a/src/thoughtworks/citibike/utils.py
+++ b/src/thoughtworks/citibike/utils.py
@@ -1,12 +1,10 @@
-import sys
-import logging
-from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 
-meters_per_foot = 0.3048
-feet_per_mile = 5280
-earth_radius_in_meters = 6371e3
-meters_per_mile = meters_per_foot * feet_per_mile
+METERS_PER_FOOT = 0.3048
+FEET_PER_MILE = 5280
+EARTH_RADIUS_METERS = 6371e3
+METERS_PER_MILE = METERS_PER_FOOT * FEET_PER_MILE
 
-def computeDistances(spark, dataframe):
+
+def compute_distances(spark, dataframe):
     return dataframe

--- a/src/thoughtworks/citibike_main.py
+++ b/src/thoughtworks/citibike_main.py
@@ -4,8 +4,8 @@ from pyspark.sql import SparkSession
 
 import thoughtworks.citibike.CitibikeTransformer as CitiBikeTransformer
 
-def main(args):
 
+def main(args):
     if len(args) < 4:
         logging.warning("Input source and output path are required")
         sys.exit(1)

--- a/src/thoughtworks/daily_driver_main.py
+++ b/src/thoughtworks/daily_driver_main.py
@@ -4,20 +4,18 @@ from pyspark.sql import SparkSession
 
 import thoughtworks.citibike.DailyDriver as DailyDriver
 
+
 def main(args):
+    if len(args) < 4:
+        logging.warning("Input source and output path are required")
+        sys.exit(1)
+    else:
+        spark = SparkSession.builder.appName("Skinny Pipeline: Ingest").getOrCreate()
+        logging.info("Application Initialized: " + spark.sparkContext.appName)
+        input_path = args[2]
+        output_path = args[3]
 
+    DailyDriver.run(spark, input_path, output_path)
+    logging.info("Application Done: " + spark.sparkContext.appName)
 
-     if len(args) < 4:
-          logging.warning("Input source and output path are required")
-          sys.exit(1)
-     else:
-          spark = SparkSession.builder.appName("Skinny Pipeline: Ingest").getOrCreate()
-          sc = spark.sparkContext
-          logging.info("Application Initialized: " + spark.sparkContext.appName)
-          input_path = args[2]
-          output_path = args[3]
-
-     DailyDriver.run(spark, input_path, output_path)
-     logging.info("Application Done: " + spark.sparkContext.appName)
-
-     spark.stop()
+    spark.stop()

--- a/src/thoughtworks/wordcount/WordCount.py
+++ b/src/thoughtworks/wordcount/WordCount.py
@@ -1,16 +1,15 @@
 import logging
 import thoughtworks.wordcount.utils as wordcount_utils
-from pyspark.sql import SparkSession
 
-def run(spark, inputPath, outputPath):
 
-    logging.info("Reading text file from: " + inputPath)
+def run(spark, input_path, output_path):
+    logging.info("Reading text file from: " + input_path)
 
-    input_df = spark.read.text(inputPath)
-    split_df = wordcount_utils.splitWords(spark, input_df)
-    count_df = wordcount_utils.countByWord(spark, split_df)
+    input_df = spark.read.text(input_path)
+    split_df = wordcount_utils.split_words(spark, input_df)
+    count_df = wordcount_utils.count_by_word(spark, split_df)
 
-    logging.info("Writing csv to directory: " + outputPath)
+    logging.info("Writing csv to directory: " + output_path)
 
-    count_df.show
-    count_df.coalesce(1).write.csv(outputPath,mode='append')
+    count_df.show()
+    count_df.coalesce(1).write.csv(output_path, mode='append')

--- a/src/thoughtworks/wordcount/utils.py
+++ b/src/thoughtworks/wordcount/utils.py
@@ -2,8 +2,10 @@ from pyspark.sql import functions as F
 
 WORD_COL = 'word'
 
-def splitWords(spark, df):
+
+def split_words(spark, df):
     return df
 
-def countByWord(spark, df):
+
+def count_by_word(spark, df):
     return df

--- a/src/thoughtworks/wordcount_main.py
+++ b/src/thoughtworks/wordcount_main.py
@@ -5,20 +5,20 @@ from pyspark.sql import SparkSession
 
 import thoughtworks.wordcount.WordCount as WordCount
 
+
 def main(args):
+    spark = SparkSession.builder.appName("Word Count").getOrCreate()
+    logging.info("Application Initialized: " + spark.sparkContext.appName)
 
-     spark = SparkSession.builder.appName("Word Count").getOrCreate()
-     logging.info("Application Initialized: " + spark.sparkContext.appName)
+    if len(args) < 4:
+        base_path = os.getcwd()
+        input_path = base_path + "/test/wordcount/data/words.txt"
+        output_path = base_path + "/test/wordcount/test-" + str(datetime.datetime.now())
+    else:
+        input_path = args[2]
+        output_path = args[3]
 
-     if len(args) < 4:
-          base_path = os.getcwd()
-          input_path = base_path + "/test/wordcount/data/words.txt"
-          output_path = base_path + "/test/wordcount/test-" + str(datetime.datetime.now())
-     else:
-          input_path = args[2]
-          output_path = args[3]
+    WordCount.run(spark, input_path, output_path)
+    logging.info("Application Done: " + spark.sparkContext.appName)
 
-     WordCount.run(spark, input_path, output_path)
-     logging.info("Application Done: " + spark.sparkContext.appName)
-
-     spark.stop()
+    spark.stop()


### PR DESCRIPTION
Forgive me if code cleanups are part of the exercise... ;)  The code has some inconsistencies (e.g. camelCase vs. snake_case) and deviations from standard Python style (PEP8) that could distract Python folks and cause unnecessary warning noise in PyCharm.  I've tried to fix most things in a minimally invasive way, but I stopped short of renaming files (e.g., WordCount.py).

Fix 5-space indents, whitespace, comments, unused variables and imports,
inconsistent naming conventions (most everything to PEP8).

job_runner: code not in a function
WordCount: count_df.show() was not being called
Tests were not consistently skipped (maybe on purpose?)