### PR TITLE
Forcing python 3.10.6 for the interview

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+# You could use `gitpod/workspace-full` as well.
+FROM gitpod/workspace-python
+
+RUN pyenv install 3.10.6 \
+    && pyenv global 3.10.6

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,10 @@
 # Please adjust to your needs (see https://www.gitpod.io/docs/config-gitpod-file)
 # and commit this file to your remote git repository to share the goodness with others.
 
+image:
+    file: .gitpod.Dockerfile
+
 tasks:
   - init: |
-      pyenv install 3.10.6
-      pyenv shell 3.10.6
       poetry install
       make tests


### PR DESCRIPTION
We don't want our gitpod workspace to run poetry with python 3.12 because some dependencies like numpy cannot be installed. Therefore we are forcing the gitpod workspace to use 3.10.6 only.